### PR TITLE
feat: build arm64 binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,23 +18,28 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y gnome-software gnome-software-common gnome-software-dev meson
+          dpkg --add-architecture arm64
+          apt update
+          apt install -y gnome-software gnome-software-dev meson gcc-aarch64-linux-gnu
 
       - name: Build
         run: |
           make
+          mv build/libgs_plugin_vso.so libgs_plugin_vso_amd64.so
+          make clean
+          apt -o Dpkg::Options::="--force-overwrite" install -y gnome-software:arm64 gnome-software-dev:arm64
+          make all-arm64
+          mv build/libgs_plugin_vso.so libgs_plugin_vso_arm64.so
 
       - name: Calculate and Save Checksums
-        run: |
-          sha256sum build/libgs_plugin_vso.so >> checksums.txt
+        run: sha256sum libgs_plugin_vso*.so >> checksums.txt
 
       - uses: actions/upload-artifact@v4
         with:
           name: gs-plugin-vso
           path: |
               checksums.txt
-              build/libgs_plugin_vso.so
+              libgs_plugin_vso*.so
 
       - uses: softprops/action-gh-release@v2
         if: github.ref == 'refs/heads/main'
@@ -45,4 +50,4 @@ jobs:
           name: "Continuous Build"
           files: |
             checksums.txt
-            build/libgs_plugin_vso.so
+            libgs_plugin_vso*.so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,23 +19,28 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y gnome-software gnome-software-common gnome-software-dev meson
+          dpkg --add-architecture arm64
+          apt update
+          apt install -y gnome-software gnome-software-dev meson gcc-aarch64-linux-gnu
 
       - name: Build
         run: |
           make
+          mv build/libgs_plugin_vso.so libgs_plugin_vso_amd64.so
+          make clean
+          apt -o Dpkg::Options::="--force-overwrite" install -y gnome-software:arm64 gnome-software-dev:arm64
+          make all-arm64
+          mv build/libgs_plugin_vso.so libgs_plugin_vso_arm64.so
 
       - name: Calculate and Save Checksums
-        run: |
-          sha256sum build/libgs_plugin_vso.so >> checksums.txt
+        run: sha256sum libgs_plugin_vso*.so >> checksums.txt
 
       - uses: actions/upload-artifact@v4
         with:
           name: gs-plugin-vso
           path: |
               checksums.txt
-              build/libgs_plugin_vso.so
+              libgs_plugin_vso*.so
 
   release:
     runs-on: ubuntu-latest
@@ -65,4 +70,4 @@ jobs:
         id: attest
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: 'build/*.so, *.txt'
+          subject-path: '*.so, *.txt'

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ all:
 	meson build
 	meson compile -C build
 
+all-arm64:
+	meson build --cross-file aarch64-linux-gnu.txt
+	meson compile -C build
+
 clean:
 	rm -rf build
 

--- a/aarch64-linux-gnu.txt
+++ b/aarch64-linux-gnu.txt
@@ -1,0 +1,11 @@
+[binaries]
+c = 'aarch64-linux-gnu-gcc'
+ar = 'aarch64-linux-gnu-ar'
+strip = 'aarch64-linux-gnu-strip'
+pkgconfig = 'aarch64-linux-gnu-pkg-config'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'aarch64'
+cpu = 'armv8'
+endian = 'little'

--- a/gs-plugin-vso.c
+++ b/gs-plugin-vso.c
@@ -124,6 +124,8 @@ static void
 gs_plugin_vso_list_apps_async(GsPlugin *plugin,
                               GsAppQuery *query,
                               GsPluginListAppsFlags flags,
+                              GsPluginEventCallback event_callback,
+                              void *event_user_data,
                               GCancellable *cancellable,
                               GAsyncReadyCallback callback,
                               gpointer user_data)
@@ -133,7 +135,7 @@ gs_plugin_vso_list_apps_async(GsPlugin *plugin,
     gboolean interactive  = (flags & GS_PLUGIN_LIST_APPS_FLAGS_INTERACTIVE);
 
     task =
-        gs_plugin_list_apps_data_new_task(plugin, query, flags, cancellable, callback, user_data);
+        gs_plugin_list_apps_data_new_task(plugin, query, flags, event_callback, event_user_data, cancellable, callback, user_data);
     g_task_set_source_tag(task, gs_plugin_vso_list_apps_async);
 
     /* Queue a job to get the apps. */


### PR DESCRIPTION
Related to https://github.com/Vanilla-OS/live-iso/issues/87.

### Requirements:
1. https://github.com/Vanilla-OS/pico-image/pull/42 be merged.
2. ARM64 packages be available in https://repo2.vanillaos.org, or use the official Debian sid repo as an alternative.